### PR TITLE
Update ZipExtraData.cs

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipExtraData.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipExtraData.cs
@@ -648,6 +648,10 @@ namespace ICSharpCode.SharpZipLib.Zip
 			{
 				localTag = ReadShortInternal();
 				localLength = ReadShortInternal();
+
+                // Fix for System Platform including the 4 previous bytes in the local length
+                localLength -= 4;
+
 				if (localTag != headerID)
 				{
 					_index += localLength;


### PR DESCRIPTION
Fix to allow the unpacking of System Platform backups where a ZipExtraData needs to be processed.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
